### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/SpectalAnalysis/Analyse_Corrected_Spectra.py
+++ b/SpectalAnalysis/Analyse_Corrected_Spectra.py
@@ -168,7 +168,7 @@ def main(fname, telluric=False, model=False):
     plt.figure()
     plt.plot(drvs, cc, '-k', lw=2)
     plt.plot(drvs, g, '--r', lw=2)
-    plt.title('CCF (mod): %s km/s' % int(RV))
+    plt.title('CCF (mod): {0!s} km/s'.format(int(RV)))
     #ax3.set_title('CCF (tel)')
     plt.xlabel('RV [km/s]')
     #ax3.set_xlabel('RV [km/s]')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:Phd-codes?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jason-neal:Phd-codes?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)